### PR TITLE
Put name on single line and widen tagline to reduce hero height

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -3,8 +3,7 @@ export default function Hero() {
     <section className="hero" id="home">
       <div className="hero-badge">Building in public</div>
       <h1 className="hero-name">
-        Shankar Rao<br />
-        <span className="hero-name-accent">Pandala</span>
+        Shankar Rao <span className="hero-name-accent">Pandala</span>
       </h1>
       <p className="hero-tagline">
         Data Scientist &amp; AI Engineer with 13+ years of experience. I build

--- a/src/index.css
+++ b/src/index.css
@@ -221,6 +221,7 @@ img {
   color: var(--text-primary);
   line-height: 1.1;
   margin-bottom: 4px;
+  white-space: nowrap;
 }
 
 .hero-name-accent {
@@ -233,7 +234,7 @@ img {
 .hero-tagline {
   font-size: clamp(14px, 1.5vw, 17px);
   color: var(--text-secondary);
-  max-width: 560px;
+  max-width: 720px;
   margin: 12px auto 20px;
   line-height: 1.6;
 }
@@ -703,6 +704,13 @@ img {
   }
   .hero {
     padding: 76px 20px 24px;
+  }
+  .hero-name {
+    font-size: 28px;
+    white-space: normal;
+  }
+  .hero-tagline {
+    max-width: 100%;
   }
   .navbar-inner {
     padding: 0 20px;


### PR DESCRIPTION
Remove line break between first/last name, add white-space: nowrap on desktop, widen tagline max-width to 720px. On mobile, font drops to 28px and allows natural wrapping.

https://claude.ai/code/session_011mZQ3fn2FLNpmw7zf78wEd