### PR TITLE
Remove min-height and justify-center from hero to eliminate gap

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -164,11 +164,9 @@ img {
 
 /* ===== Hero ===== */
 .hero {
-  min-height: 33vh;
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
   text-align: center;
   padding: 72px 48px 16px;
   position: relative;


### PR DESCRIPTION
Let the hero section size to its content instead of enforcing 33vh.

https://claude.ai/code/session_011mZQ3fn2FLNpmw7zf78wEd