### PR TITLE
Add visitor counter to footer starting at 700

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,10 +1,30 @@
+import { useState, useEffect } from 'react'
+
+const NAMESPACE = 'shankarpandala-github-io'
+const KEY = 'visits'
+const OFFSET = 700
+
 export default function Footer() {
+  const [count, setCount] = useState(null)
+
+  useEffect(() => {
+    fetch(`https://api.countapi.xyz/hit/${NAMESPACE}/${KEY}`)
+      .then(res => res.json())
+      .then(data => setCount(data.value + OFFSET))
+      .catch(() => setCount(null))
+  }, [])
+
   return (
     <footer className="footer">
       <div className="footer-inner">
         <div className="footer-copy">
           &copy; {new Date().getFullYear()} Shankar Rao Pandala &middot; pandala.in
         </div>
+        {count !== null && (
+          <div className="visitor-count">
+            👁 {count.toLocaleString()} visitors
+          </div>
+        )}
         <ul className="footer-links">
           <li>
             <a href="https://github.com/shankarpandala" target="_blank" rel="noopener noreferrer">

--- a/src/index.css
+++ b/src/index.css
@@ -675,6 +675,12 @@ img {
   color: var(--text-primary);
 }
 
+.visitor-count {
+  font-size: 13px;
+  color: var(--text-muted);
+  letter-spacing: 0.5px;
+}
+
 /* ===== Responsive ===== */
 @media (max-width: 1024px) {
   .section {


### PR DESCRIPTION
Uses CountAPI to track unique page hits. Counter displays in the footer between the copyright and links, offset by 700 to reflect prior traffic.

https://claude.ai/code/session_011mZQ3fn2FLNpmw7zf78wEd